### PR TITLE
fix: 修复类型推论的错误,引入 @types 描述文件

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
     "sequelize-ts"
   ],
   "dependencies": {
+    "@types/node": "*",
+    "@types/bluebird": "^3.5.33",
+    "@types/validator": "^13.1.1",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^5.5.1",
-    "sequelize-typescript": "^1.0.0-alpha.9"
+    "sequelize-typescript": "^1.1.0"
   },
   "devDependencies": {
     "autod": "^3.0.1",


### PR DESCRIPTION
## bug fix

### 问题描述

在使用时发现 `typescript` 的类型推论无法正常运作，如下图

![image](https://user-images.githubusercontent.com/22976711/100998185-29590b00-3596-11eb-834e-a51fd6fa397d.png)

可见泛型 `M` 按规范传入之后，并未在 `Promise<M>` 中正确返回，并且在实际情况中，我看到返回都是 `any`

### 问题调查

1. 经调查发现，sequelize 在 `sequelize/types/lib/promise.d.ts` 使用了 `@types/bluebird`，这个描述文件覆写了 `Promise` 的描述
2. 在 `sequelize/types/lib/model.d.ts` 中大量引入了 `sequelize/types/lib/promise.d.ts` 的 `Promise`
3. 在没有安装 `@types/bluebird` 时，`sequelize/types/lib/promise.d.ts` 使用的 `Promise` 就会找不到，变成了 `any`，也就重现了上图的情况

### 解决途径

1. 正确安装 `@types/bluebird` 依赖，并将其设置为 `dependencies`，保证用户在使用此依赖时同时也安装 `@types/bluebird` 描述文件
2. 在查看了 sequelize 的 gitpage 之后，发现该项目也在「installation」中提示安装 `@types/bluebird`，链接如下 [sequelize-typescript#installation](https://github.com/RobinBuschmann/sequelize-typescript#installation)

> ps: 当然，通过用户自己安装 `@types/bluebird` 也可以解决问题，但是 `egg-typescript-sequelize` 插件作为对 `sequelize` 和 `sequelize-typescript` 的一层封装，这个描述文件依赖由插件来安装更好

> ps2: sequelize 的使用者也有同样的疑惑。。。这里给上 issues 地址 [sequelize/issues/10928](https://github.com/sequelize/sequelize/issues/10928)